### PR TITLE
feat(settings-tab): Color settings display depending on color approach

### DIFF
--- a/src/@types/settings.d.ts
+++ b/src/@types/settings.d.ts
@@ -23,9 +23,7 @@ type MindMapSettings = {
 
   initialExpandLevel: number;
 
-  onlyUseDefaultColor: boolean;
-
-  coloring: "depth" | "branch";
+  coloring: "depth" | "branch" | "single";
 
   colorFreezeLevel: number;
   animationDuration: number;

--- a/src/inline-renderer.ts
+++ b/src/inline-renderer.ts
@@ -97,7 +97,7 @@ export const inlineRenderer: Renderer =
 
 function applyColor(frontmatterColors: string[], settings: MindMapSettings) {
   return ({ depth }: INode) => {
-    if (settings.onlyUseDefaultColor) return settings.defaultColor;
+    if (settings.coloring == "single") return settings.defaultColor;
 
     const colors = frontmatterColors?.length
       ? frontmatterColors

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { inlineRenderer } from "./inline-renderer";
 
 import { ScreenshotBgStyle } from "./@types/screenshot";
 
-const DEFAULT_SETTINGS = {
+const DEFAULT_SETTINGS: MindMapSettings = {
   splitDirection: "horizontal",
   nodeMinHeight: 16,
   lineHeight: "1em",
@@ -27,8 +27,6 @@ const DEFAULT_SETTINGS = {
   defaultColorThickness: "2",
 
   initialExpandLevel: -1,
-
-  onlyUseDefaultColor: false,
 
   coloring: "depth",
 

--- a/src/mindmap-view.ts
+++ b/src/mindmap-view.ts
@@ -273,7 +273,7 @@ export default class MindmapView extends ItemView {
 
   applyColor(frontmatterColors: string[]) {
     return ({ depth }: INode) => {
-      if (this.settings.onlyUseDefaultColor) return this.settings.defaultColor;
+      if (this.settings.coloring == "single") return this.settings.defaultColor;
 
       const colors = frontmatterColors?.length
         ? frontmatterColors

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -112,22 +112,36 @@ export class MindMapSettingsTab extends PluginSettingTab {
           })
       );
 
-    new Setting(containerEl)
-      .setName("Coloring approach")
-      .setDesc(
-        "The 'depth' changes the color on each level, 'branch' changes the color on each new branch"
-      )
-      .addDropdown((dropDown) =>
-        dropDown
-          .addOption("depth", "Depth based coloring")
-          .addOption("branch", "Branch based coloring")
-          .setValue(this.plugin.settings.coloring || "depth")
-          .onChange((value: "branch" | "depth") => {
-            this.plugin.settings.coloring = value;
-            save();
-          })
-      );
+    function decide_display_colors(approach: MindMapSettings['coloring']) {
+      const all = [color_1, color_2, color_3, color_default]
+      const settings = {
+        branch: [],
+        depth: all,
+        single: [color_default]
+      }
+      all.forEach(setting => setting.settingEl.hidden = true)
+      settings[approach].forEach(setting => setting.settingEl.hidden = false)
+    }
 
+    new Setting(containerEl)
+    .setName("Coloring approach")
+    .setDesc(
+      "The 'depth' changes the color on each level, 'branch' changes the color on each new branch"
+    )
+    .addDropdown((dropDown) =>
+      dropDown
+        .addOption("depth", "Depth based coloring")
+        .addOption("branch", "Branch based coloring")
+        .addOption("single", "Single color")
+        .setValue(this.plugin.settings.coloring || "depth")
+        .onChange((value: "branch" | "depth" | "single") => {
+          this.plugin.settings.coloring = value;
+          save();
+          decide_display_colors(value);
+        })
+    );
+
+    const color_1 =
     new Setting(containerEl)
       .setName("Color 1")
       .setDesc("Color for the first level of the mind map")
@@ -154,6 +168,7 @@ export class MindMapSettingsTab extends PluginSettingTab {
           })
       );
 
+    const color_2 =
     new Setting(containerEl)
       .setName("Color 2")
       .setDesc("Color for the second level of the mind map")
@@ -178,6 +193,7 @@ export class MindMapSettingsTab extends PluginSettingTab {
           })
       );
 
+    const color_3 =
     new Setting(containerEl)
       .setName("Color 3")
       .setDesc("Color for the third level of the mind map")
@@ -202,6 +218,7 @@ export class MindMapSettingsTab extends PluginSettingTab {
           })
       );
 
+    const color_default =
     new Setting(containerEl)
       .setName("Default Color")
       .setDesc("Color for fourth level and beyond")
@@ -222,18 +239,6 @@ export class MindMapSettingsTab extends PluginSettingTab {
           .setValue(this.plugin.settings.defaultColorThickness)
           .onChange((value) => {
             this.plugin.settings.defaultColorThickness = value;
-            save();
-          })
-      );
-
-    new Setting(containerEl)
-      .setName("Only use default color")
-      .setDesc("When on, all branches uses the default color")
-      .addToggle((toggle) =>
-        toggle
-          .setValue(this.plugin.settings.onlyUseDefaultColor)
-          .onChange((value) => {
-            this.plugin.settings.onlyUseDefaultColor = value;
             save();
           })
       );
@@ -369,5 +374,7 @@ export class MindMapSettingsTab extends PluginSettingTab {
           save();
         })
       );
+
+    decide_display_colors(this.plugin.settings.coloring)
   }
 }

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -3,11 +3,27 @@ import { App, PluginSettingTab, Setting, SplitDirection } from "obsidian";
 import MindMap from "./main";
 import { ScreenshotBgStyle } from "./@types/screenshot";
 
+type ColorSettings = Record<number | 'default', Setting>
+
 export class MindMapSettingsTab extends PluginSettingTab {
   plugin: MindMap;
+  colorSettings: ColorSettings;
   constructor(app: App, plugin: MindMap) {
     super(app, plugin);
     this.plugin = plugin;
+    this.colorSettings = {} as ColorSettings;
+  }
+
+  decideDisplayColors() {
+    const approach = this.plugin.settings.coloring;
+    const colors = this.colorSettings;
+    const options = {
+      branch: [] as Setting[],
+      depth: [colors[1], colors[2], colors[3], colors.default],
+      single: [colors.default]
+    };
+    Object.values(this.colorSettings).forEach(setting => setting.settingEl.hidden = true);
+    options[approach].forEach(setting => setting.settingEl.hidden = false);
   }
 
   display(): void {
@@ -112,17 +128,6 @@ export class MindMapSettingsTab extends PluginSettingTab {
           })
       );
 
-    function decide_display_colors(approach: MindMapSettings['coloring']) {
-      const all = [color_1, color_2, color_3, color_default]
-      const settings = {
-        branch: [],
-        depth: all,
-        single: [color_default]
-      }
-      all.forEach(setting => setting.settingEl.hidden = true)
-      settings[approach].forEach(setting => setting.settingEl.hidden = false)
-    }
-
     new Setting(containerEl)
     .setName("Coloring approach")
     .setDesc(
@@ -137,12 +142,11 @@ export class MindMapSettingsTab extends PluginSettingTab {
         .onChange((value: "branch" | "depth" | "single") => {
           this.plugin.settings.coloring = value;
           save();
-          decide_display_colors(value);
+          this.decideDisplayColors();
         })
     );
 
-    const color_1 =
-    new Setting(containerEl)
+    this.colorSettings[1] = new Setting(containerEl)
       .setName("Color 1")
       .setDesc("Color for the first level of the mind map")
       .addColorPicker((colPicker) =>
@@ -168,8 +172,7 @@ export class MindMapSettingsTab extends PluginSettingTab {
           })
       );
 
-    const color_2 =
-    new Setting(containerEl)
+    this.colorSettings[2] = new Setting(containerEl)
       .setName("Color 2")
       .setDesc("Color for the second level of the mind map")
       .addColorPicker((colPicker) =>
@@ -193,8 +196,7 @@ export class MindMapSettingsTab extends PluginSettingTab {
           })
       );
 
-    const color_3 =
-    new Setting(containerEl)
+    this.colorSettings[3] = new Setting(containerEl)
       .setName("Color 3")
       .setDesc("Color for the third level of the mind map")
       .addColorPicker((colPicker) =>
@@ -218,8 +220,7 @@ export class MindMapSettingsTab extends PluginSettingTab {
           })
       );
 
-    const color_default =
-    new Setting(containerEl)
+    this.colorSettings.default = new Setting(containerEl)
       .setName("Default Color")
       .setDesc("Color for fourth level and beyond")
       .addColorPicker((colPicker) =>
@@ -375,6 +376,6 @@ export class MindMapSettingsTab extends PluginSettingTab {
         })
       );
 
-    decide_display_colors(this.plugin.settings.coloring)
+    this.decideDisplayColors();
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -81,3 +81,7 @@ color: black;
 .markmap-toolbar-container .mm-toolbar .mm-toolbar-item:hover {
 color: brown;
 }
+
+[hidden] {
+    display: none;
+}


### PR DESCRIPTION
Implements #68.
"Use only default color" is removed and "Colouring approach" has a new option, "Single colour".
The colour settings are hidden when not usable.

<img width="653" alt="image" src="https://user-images.githubusercontent.com/10291002/211249675-68a78dbf-1183-4691-a948-4ed819bf4af1.png">

<img width="645" alt="image" src="https://user-images.githubusercontent.com/10291002/211250187-17ab7e0f-a458-43d2-a8cb-7b37f95be951.png">

<img width="653" alt="image" src="https://user-images.githubusercontent.com/10291002/211250082-6a6791df-245f-4076-ac87-b54fc4642149.png">
