### PR TITLE
feat: use document title as root node (optionally)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A similar plugin is available for [Visual Studio Code](https://marketplace.visua
 - [x] Copy preview to clipboard as PNG image
 - [x] Implements Katex (LaTex plugin)
 - [x] Implements checkmarks (such as this list)
-- [x] Has branch coloring branch and depth coloring branch approaches
+- [x] Has branch coloring and depth coloring approaches
 - [x] Avoids XSS injection.
 
 #### Below an preview image with the default content of the official [markmap website](https://markmap.js.org/repl) try it out. Just with the `maxWidth` option.
@@ -52,15 +52,42 @@ You can open the Mind Map preview for the current note with a command.
 
 The plugin also accepts frontmatter options (each of the [official markmap docs](https://markmap.js.org/docs/json-options) except for `extraJs` and `extraCss`). Frontmatter options has higher priority than the settings from the settings tab which means that if you set `maxWidth` on settings to 400px and on frontmatter to 200px, the maxWidth will be set to 200px.
 
-The colors you list will always be used, no matter which coloring approach is set. Only colorFreezeLevel that only works with branch coloring approach. It is good to note that when using branch coloring approach and no color is listed, random colors will be used (as the default Markmap approach).
+The settings in each document's frontmatter take priority over those selected in your plugin settings.
 
 It is also good to note that the frontmatter only works for that markdown it is in. If you open another Markdown file without frontmatter, the settings from settings tab will be used.
 
-More than the default frontmatter options, it also supports another options (and may be upcomming more options):
+As well as the default frontmatter options, it also supports these other options (and maybe more soon):
 
 **screenshotTextColor:** Set the text color of the screenshot. It accepts any valid CSS color (hex, color name, rgb, rgba and hsl). This color is applied to screenshots only, and not while using the plugin.
 
 **highlight:** A boolean option that allows you to activate a border and a different background color for the inline markmap. If the frontmatter setting is present, it will have higher priority than the settings tab.
+
+**titleAsRootNode:** Set the ["Use title as root node" option](#document-title-as-root-node) for this document.
+
+**Example:**
+```markdown
+---
+markmap:
+  screenshotFgColor: #28F48D
+  highlight: true
+  titleAsRootNode: true
+---
+```
+
+### Coloring approaches
+There are three approaches to coloring the branches of the mind map for you to choose from, either in plugin settings or each document's frontmatter.
+
+#### Branch coloring
+This mode will choose random different colors per branch. The "Color freeze level" setting decides at what depth the branches will stop picking new colors.
+
+#### Depth coloring
+In this mode, branches are coloured depending on their depth level. In your plugin settings, you can choose the first three levels' colors, plus a default color for levels deeper than three.
+
+#### Single color
+In this mode, all branches are colored with a single color, which you can choose in your plugin settings.
+
+#### Branch thickness
+Regardless which coloring approach you choose, you can set branch thickness for the first three depth levels, and a default thickness for levels beyond that.
 
 ### Inline Markmap
 
@@ -161,6 +188,18 @@ Places a copy of the Mind Map SVG on your clipboard allowing you to paste it int
 #### Collapse all
 
 Hides all nodes except the root.
+
+### Document title as root node
+
+Select "Use title as root node" in plugin settings to generate mind maps with the title at the bottom level, so you can avoid repeating the title.
+You can also enable this setting per document by putting ```titleAsRootNode: true``` inside a ```markmap:``` block in the frontmatter at the top of your document.
+```markdown
+---
+markmap:
+   titleAsRootNode: true
+---
+document text
+```
 
 ## Compatibility
 

--- a/src/@types/models.d.ts
+++ b/src/@types/models.d.ts
@@ -5,6 +5,7 @@ type FrontmatterOptions = Partial<IMarkmapOptions> & {
   screenshotTextColor?: string;
   screenshotBgColor: string;
   highlight?: boolean;
+  titleAsRootNode: boolean;
 };
 
 type TokenWithChildren = Remarkable.Remarkable.Token & {
@@ -17,5 +18,6 @@ type CustomFrontmatter = {
     screenshotTextColor: string;
     screenshotBgColor: string;
     highlight?: boolean;
+    titleAsRootNode: boolean;
   };
 };

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,17 @@
+
+export class LocalEvents<EventName extends string> {
+  private listeners: Record<string, Function[]> = {};
+
+  public emit(name: EventName, data: any) {
+    const listeners = this.listeners[name];
+    if (!listeners) return
+    listeners.forEach(cb => cb(data))
+  }
+
+  public listen(name: EventName, callback: Function) {
+    if (this.listeners[name])
+      this.listeners[name].push(callback)
+    else
+      this.listeners[name] = [callback]
+  }
+}

--- a/src/filesystem-data.test.ts
+++ b/src/filesystem-data.test.ts
@@ -71,6 +71,7 @@ describe("Filesystem Data Manager", () => {
         highlight: true,
         screenshotBgColor: '#002b36',
         screenshotBgStyle: ScreenshotBgStyle.Color,
+        titleAsRootNode: true
       }
     }
 
@@ -144,6 +145,7 @@ describe("Filesystem Data Manager", () => {
         highlight: false,
         screenshotBgColor: 'r6t7y',
         screenshotBgStyle: ScreenshotBgStyle.Theme,
+        titleAsRootNode: true
       }
     }
 
@@ -210,6 +212,7 @@ describe("Filesystem Data Manager", () => {
         highlight: false,
         screenshotBgColor: 'r6t7y',
         screenshotBgStyle: ScreenshotBgStyle.Theme,
+        titleAsRootNode: true
       }
     }
 

--- a/src/filesystem-data.ts
+++ b/src/filesystem-data.ts
@@ -55,6 +55,7 @@ export const defaults: v2['settings'] = {
   screenshotBgStyle: ScreenshotBgStyle.Color,
   screenshotTextColor: "#fdf6e3",
   screenshotTextColorEnabled: false,
+  titleAsRootNode: true
 }
 
 const defaultsV1: v1_1 = {
@@ -163,6 +164,7 @@ type Settings2_0 = {
   screenshotTextColorEnabled: boolean
 
   coloring: Coloring
+  titleAsRootNode: boolean
 }
 
 export type v2 = {

--- a/src/filesystem-data.ts
+++ b/src/filesystem-data.ts
@@ -9,7 +9,7 @@ export enum ScreenshotBgStyle {
 /**
  * Given a version number MAJOR.MINOR, increment the:
  * 1. MAJOR version when previously valid keys are removed or have a different function
- * 2. MINOR version when only new keys have been added
+ * 2. MINOR version - Deprecated. If you are adding a key, just add it to the type and the defaults.
  */
 
 const omit = <T, U extends keyof T>(keys: readonly U[], obj: T): Omit<T, U> =>
@@ -28,7 +28,7 @@ function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K> {
 
 
 // Default settings
-export const defaults: v2_0['settings'] = {
+export const defaults: v2['settings'] = {
   splitDirection: "horizontal",
   nodeMinHeight: 16,
   lineHeight: "1em",
@@ -52,11 +52,41 @@ export const defaults: v2_0['settings'] = {
   defaultThickness: "1",
 
   screenshotBgColor: "#002b36",
-  screenshotBgStyle: ScreenshotBgStyle.Transparent,
+  screenshotBgStyle: ScreenshotBgStyle.Color,
   screenshotTextColor: "#fdf6e3",
-  screenshotTextColorEnabled: false
+  screenshotTextColorEnabled: false,
 }
 
+const defaultsV1: v1_1 = {
+  splitDirection:     defaults.splitDirection,
+  nodeMinHeight:      defaults.nodeMinHeight,
+  lineHeight:         defaults.lineHeight,
+  spacingVertical:    defaults.spacingVertical,
+  spacingHorizontal:  defaults.spacingHorizontal,
+  paddingX:           defaults.paddingX,
+  initialExpandLevel: defaults.initialExpandLevel,
+  defaultColor:       defaults.defaultColor,
+  colorFreezeLevel:   defaults.colorFreezeLevel,
+  animationDuration:  defaults.animationDuration,
+  maxWidth:           defaults.maxWidth,
+  highlight:          defaults.highlight,
+  screenshotBgColor:  defaults.screenshotBgColor,
+  screenshotBgStyle:  defaults.screenshotBgStyle,
+
+  color1:                   defaults.depth1Color,
+  color1Thickness:          defaults.depth1Thickness,
+  color2:                   defaults.depth2Color,
+  color2Thickness:          defaults.depth2Thickness,
+  color3:                   defaults.depth3Color,
+  color3Thickness:          defaults.depth3Thickness,
+  defaultColorThickness:    defaults.defaultThickness,
+  screenshotFgColor:        defaults.screenshotTextColor,
+  screenshotFgColorEnabled: defaults.screenshotTextColorEnabled,
+
+  coloring: "depth",
+  onlyUseDefaultColor: false,
+  screenshotTransparentBg: false
+}
 
 
 //  Version 1.0
@@ -96,44 +126,10 @@ export type v1_1 = v1_0 & {
 }
 
 // Upgrade from v1.0 to v1.1
-const upgrade1_1 = (data: v1_0): v1_1 => {
-  const unchanged = {
-    splitDirection:        data.splitDirection,
-    nodeMinHeight:         data.nodeMinHeight,
-    lineHeight:            data.lineHeight,
-    spacingVertical:       data.spacingVertical,
-    spacingHorizontal:     data.spacingHorizontal,
-    paddingX:              data.paddingX,
-    initialExpandLevel:    data.initialExpandLevel,
-    color1:                data.color1,
-    color1Thickness:       data.color1Thickness,
-    color2:                data.color2,
-    color2Thickness:       data.color2Thickness,
-    color3:                data.color3,
-    color3Thickness:       data.color3Thickness,
-    defaultColor:          data.defaultColor,
-    defaultColorThickness: data.defaultColorThickness,
-    onlyUseDefaultColor:   data.onlyUseDefaultColor,
-  }
-
-  const added = {
-    coloring:                 "depth" as v1_1['coloring'],
-    colorFreezeLevel:         defaults.colorFreezeLevel,
-    animationDuration:        defaults.animationDuration,
-    maxWidth:                 defaults.maxWidth,
-    highlight:                defaults.highlight,
-    screenshotBgColor:        defaults.screenshotBgColor,
-    screenshotBgStyle:        defaults.screenshotBgStyle,
-    screenshotTransparentBg:  false,
-    screenshotFgColor:        defaults.screenshotTextColor,
-    screenshotFgColorEnabled: defaults.screenshotTextColorEnabled,
-  }
-
-  return {
-    ...unchanged,
-    ...added
-  }
-}
+const upgrade1_1 = (data: v1_0): v1_1 => ({
+  ...defaultsV1,
+  ...data
+})
 
 
 //  Version 2.0
@@ -141,40 +137,40 @@ const upgrade1_1 = (data: v1_0): v1_1 => {
 export type Coloring = "depth" | "branch" | "single"
 
 type Settings2_0 = {
-  splitDirection: SplitDirection,
-  nodeMinHeight: number,
-  lineHeight: string,
-  spacingVertical: number,
-  spacingHorizontal: number,
-  paddingX: number,
-  initialExpandLevel: number,
-  defaultColor: string,
-  colorFreezeLevel: number,
-  animationDuration: number,
-  maxWidth: number,
-  highlight: boolean,
-  screenshotBgColor: string,
-  screenshotBgStyle: ScreenshotBgStyle,
+  splitDirection: SplitDirection
+  nodeMinHeight: number
+  lineHeight: string
+  spacingVertical: number
+  spacingHorizontal: number
+  paddingX: number
+  initialExpandLevel: number
+  defaultColor: string
+  colorFreezeLevel: number
+  animationDuration: number
+  maxWidth: number
+  highlight: boolean
+  screenshotBgColor: string
+  screenshotBgStyle: ScreenshotBgStyle
 
-  depth1Color: string,
-  depth1Thickness: string,
-  depth2Color: string,
-  depth2Thickness: string,
-  depth3Color: string,
-  depth3Thickness: string,
-  defaultThickness: string,
-  screenshotTextColor: string,
-  screenshotTextColorEnabled: boolean,
+  depth1Color: string
+  depth1Thickness: string
+  depth2Color: string
+  depth2Thickness: string
+  depth3Color: string
+  depth3Thickness: string
+  defaultThickness: string
+  screenshotTextColor: string
+  screenshotTextColorEnabled: boolean
 
   coloring: Coloring
 }
 
-export type v2_0 = {
-  version: "2.0",
+export type v2 = {
+  version: "2.0"
   settings: Settings2_0
 }
 
-const upgrade2_0 = (data: v1_1): v2_0 => {
+const upgrade2_0 = (data: v1_1): v2 => {
   const removed = ["onlyUseDefaultColor", "screenshotTransparentBg"];
 
   const unchanged = {
@@ -214,6 +210,7 @@ const upgrade2_0 = (data: v1_1): v2_0 => {
   return {
     version: '2.0',
     settings: {
+      ...defaults,
       ...unchanged,
       ...renamed,
       ...transformed
@@ -221,13 +218,22 @@ const upgrade2_0 = (data: v1_1): v2_0 => {
   }
 }
 
-const defaults2_0 = (): v2_0 => ({
+const defaultsV2 = (): v2 => ({
   version: '2.0',
   settings: defaults
 })
 
-export type PluginSettings = v2_0["settings"];
-type FileSystemData = v2_0;
+const useDefaultsForMissingKeys =
+(data: any): v2 => ({
+  version: '2.0',
+  settings: {
+    ...defaults,
+    ...data.settings
+  }
+})
+
+export type PluginSettings = v2["settings"];
+type FileSystemData = v2;
 const latestVersion = "2.0";
 
 const isObject = (x: any) => typeof x === "object" && x !== null;
@@ -244,7 +250,8 @@ const detectVersion = (data: any) =>
 const upgrades = {
   "1.0": upgrade1_1,
   "1.1": upgrade2_0,
-  ""   : defaults2_0,
+  "2.0": useDefaultsForMissingKeys,
+  ""   : defaultsV2,
 }
 
 function upgrade(data: any): FileSystemData {
@@ -255,7 +262,7 @@ function upgrade(data: any): FileSystemData {
     if (version !== latestVersion)
       accumulator = upgrades[version](accumulator)
     else
-      return accumulator;
+      return upgrades[latestVersion](accumulator);
   }
 }
 
@@ -267,7 +274,7 @@ type SettingsManager = {
   getAll: () => PluginSettings // avoid
 }
 
-export async function FileSystemManager (
+export async function getFilesystemData (
   loadData: Plugin_2['loadData'],
   saveData: Plugin_2['saveData']
 ): Promise<[SettingsManager]>

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { MM_VIEW_TYPE } from "./constants";
 import { SettingsTab } from "./settings-tab";
 import { inlineRenderer, pickInlineRendererSettings } from "./inline-renderer";
 
-import { FileSystemManager, PluginSettings } from "./filesystem-data";
+import { getFilesystemData, PluginSettings } from "./filesystem-data";
 
 export default class Plugin extends ObsidianPlugin {
 
@@ -15,7 +15,7 @@ export default class Plugin extends ObsidianPlugin {
     const loadData = this.loadData.bind(this);
     const saveData = this.saveData.bind(this);
 
-    const [settings] = await FileSystemManager(loadData, saveData);
+    const [settings] = await getFilesystemData(loadData, saveData);
 
     this.registerView(
       MM_VIEW_TYPE,


### PR DESCRIPTION
Implements #60.

With one top-level heading:
<img width="353" alt="" src="https://user-images.githubusercontent.com/10291002/211262336-a87f6009-72f1-45a3-a9d0-1903c10c955e.png">


With multiple top-level headings:
<img width="289" alt="" src="https://user-images.githubusercontent.com/10291002/211262258-ef87c2bd-d860-44aa-a05d-f4e7415258e5.png">
