### PR TITLE
fix: code blocks crashing render

### DIFF
--- a/src/mindmap-view.ts
+++ b/src/mindmap-view.ts
@@ -262,8 +262,22 @@ export default class MindmapView extends ItemView {
     }
   }
 
+  sanitiseMarkdown(markdown: string) {
+    // Remove info string from code fence unless it is "js" or "javascript"
+    // transformer.transform can't handle other languages
+    const allowedLanguages = ["js", "javascript", "css", "html"]
+    return markdown.replace(/```(.+)/, (_, capture) => {
+      const backticks = capture.match(/(`*).*/)?.[1]
+      const infoString = capture.match(/`*(.*)/)?.[1]
+      const t = infoString?.trim()
+      const sanitisedInfoString = allowedLanguages.includes(t) ? t : ""
+      return "```" + (backticks || "") + sanitisedInfoString
+    })
+  }
+
   async transformMarkdown(markdown: string) {
-    let { root, features, frontmatter } = this.transformer.transform(markdown);
+    const sanitisedMarkdown = this.sanitiseMarkdown(markdown)
+    let { root, features, frontmatter } = this.transformer.transform(sanitisedMarkdown);
 
     const { scripts, styles } = this.transformer.getUsedAssets(features);
 


### PR DESCRIPTION
Fixes #73.

The problem seems to be in the Transformer class imported from markmap-lib.
It crashes on most languages specified on a code block. I allows js, javascript, css, html and highlights their syntax. Maybe there are others that work.