### PR TITLE
feat: mindmap codeblock bg-color matches theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,17 @@
     line-height: var(--mm-line-height, 1em);
 }
 
+/* Remove markmap's code block style */
+.markmap-foreign.markmap-foreign code {
+    color: inherit;
+    background-color: inherit;
+}
+
+/* Hide language tag shown by some themes */
+.markmap-foreign pre[class*='language-']::after {
+    display: none;
+}
+
 
 /* Checkboxes */
 


### PR DESCRIPTION
Code blocks now take the theme background-color. I haven't added any settings.

If we could get the markmap codeblocks to render more like the Obsidian codeblocks, we'd fix the problem of only allowing a limited set of syntax highlightings without adding more dependencies. Not sure if this is feasible.

(+ the syntax highlighting would match the theme)