### PR TITLE
fix: internal links break with &, | chars

### DIFF
--- a/src/rendering/linker.ts
+++ b/src/rendering/linker.ts
@@ -15,17 +15,33 @@ function replaceInternalLinks(node: INode) {
   for (let i = 0; i < matches.length; i++) {
     const match = matches[i];
     const isWikiLink = match.groups!["wikitext"];
-    const linkText = isWikiLink
+    var linkText = isWikiLink
       ? match.groups!["wikitext"]
       : match.groups!["mdtext"];
-    const linkPath = isWikiLink ? linkText : match.groups!["mdpath"];
+    var linkPath = isWikiLink ? linkText : match.groups!["mdpath"];
     if (linkPath.startsWith("http")) {
       continue;
     }
     const vaultName = app.vault.getName();
-    const url = `obsidian://open?vault=${vaultName}&file=${
-      isWikiLink ? encodeURI(getLinkpath(linkPath)) : linkPath
-    }`;
+    //const url = `obsidian://open?vault=${vaultName}&file=${isWikiLink ? encodeURI(getLinkpath(linkPath)) : linkPath}`;
+    var url = "";
+    if(isWikiLink){
+      //"&": [[A & B]]
+      linkPath = linkPath.replace(/&amp;/g, "&");
+      //"|": [[A & B|AB]]
+      const regex = /^(.*?)\|(.*)$/;
+      const match_link_text = regex.exec(linkPath);
+      if(match_link_text && match_link_text.length === 3){
+        linkText = match_link_text[2];
+        linkPath = match_link_text[1].trim();
+      }
+      url = `obsidian://open?vault=${vaultName}&file=${encodeURIComponent(getLinkpath(linkPath))}`;
+    }
+    else{
+      //"&": [AB](<A & B.md>)
+      linkPath = linkPath.replace(/&amp;/g, "%26");
+      url = `obsidian://open?vault=${vaultName}&file=${linkPath}`;
+    }    
     const link = `<a href=\"${url}\">${linkText}</a>`;
     node.content = node.content.replace(match[0], link);
   }

--- a/src/rendering/linker.ts
+++ b/src/rendering/linker.ts
@@ -15,20 +15,19 @@ function replaceInternalLinks(node: INode) {
   for (let i = 0; i < matches.length; i++) {
     const match = matches[i];
     const isWikiLink = match.groups!["wikitext"];
-    var linkText = isWikiLink
+    let linkText = isWikiLink
       ? match.groups!["wikitext"]
       : match.groups!["mdtext"];
-    var linkPath = isWikiLink ? linkText : match.groups!["mdpath"];
+    let linkPath = isWikiLink ? linkText : match.groups!["mdpath"];
     if (linkPath.startsWith("http")) {
       continue;
     }
     const vaultName = app.vault.getName();
-    //const url = `obsidian://open?vault=${vaultName}&file=${isWikiLink ? encodeURI(getLinkpath(linkPath)) : linkPath}`;
-    var url = "";
-    if(isWikiLink){
-      //"&": [[A & B]]
+    let url = "";
+    if (isWikiLink) {
+      // "&": [[A & B]]
       linkPath = linkPath.replace(/&amp;/g, "&");
-      //"|": [[A & B|AB]]
+      // "|": [[A & B|AB]]
       const regex = /^(.*?)\|(.*)$/;
       const match_link_text = regex.exec(linkPath);
       if(match_link_text && match_link_text.length === 3){
@@ -36,9 +35,8 @@ function replaceInternalLinks(node: INode) {
         linkPath = match_link_text[1].trim();
       }
       url = `obsidian://open?vault=${vaultName}&file=${encodeURIComponent(getLinkpath(linkPath))}`;
-    }
-    else{
-      //"&": [AB](<A & B.md>)
+    } else {
+      // "&": [AB](<A & B.md>)
       linkPath = linkPath.replace(/&amp;/g, "%26");
       url = `obsidian://open?vault=${vaultName}&file=${linkPath}`;
     }    


### PR DESCRIPTION
This PR fixes an issue(#133) where internal links containing & and | characters, such as `[[A & B]]`, `[[A & B|AB]]`, `[AB](<A & B.md>)`.